### PR TITLE
Meeting tab with schedule and event calendar include

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,6 +3,7 @@ layout: col-sidebar
 title: OWASP Project Committee
 tags: project-committee
 pitch: Help all OWASP Projects to succeed
+altfooter: true
 ---
 
 ## Mission Statement

--- a/tab_meetings.md
+++ b/tab_meetings.md
@@ -1,0 +1,21 @@
+---
+title: Meetings
+layout:  null
+altfooter: true
+tab: true
+order: 1
+tags: project-committee
+---
+
+## Meetings
+
+The Project Committee meets on **the 4th Wednesday of every month at
+14:00 UTC** virtually via Google Meet. OWASP Members can access the
+perpetual meeting minutes at
+<https://docs.google.com/document/d/12MaHpNFgDMFG5FHXpqJmCorv4R586bbF6MJqliZrg5k>.
+
+You can also find the meeting dates of the Project Commitee in the
+official OWASP Event Calendar:
+
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=2&amp;bgcolor=%23ffffff&amp;ctz=UTC&amp;src=aGw2Y2pnczZlcDFoN29uaXFndWV1MmJoYm9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showNav=1&amp;showCalendars=0&amp;showTabs=0&amp;showPrint=0&amp;showDate=1&amp;hl=en&amp;mode=AGENDA" style="border:solid 1px #777" width="400" height="600" frameborder="0" scrolling="no"></iframe>
+


### PR DESCRIPTION
Possible improvement: Filter the Google Calendar embed to only show _Project Committee Meeting_ events.