### PR TITLE
Add preliminary version of "Support for Projects" section

### DIFF
--- a/_includes/support_for_projects.md
+++ b/_includes/support_for_projects.md
@@ -1,0 +1,29 @@
+<div class="alert">
+DRAFT Document
+</div>
+
+### Support for Projects
+
+As an OWASP Project Leader you have access to various supporting services and resources to help your project thrive.
+
+#### Project-specific Expenses
+
+Project-specific expenses under USD $250 and covered by the requirements for [Fair and Reasonable Expenses](https://owasp.org/www-policy/operational/expense-reimbursement#fair-and-reasonable-expenses) do not require pre-approval and can simply be submitted for reimbursement via [this form](https://owasporg.atlassian.net/servicedesk/customer/portal/4/group/12).
+
+[Fair and Reasonable Expenses](https://owasp.org/www-policy/operational/expense-reimbursement#fair-and-reasonable-expenses) over USD $250 require a pre-approval via [this form](https://owasporg.atlassian.net/servicedesk/customer/portal/4/group/9) by two Project Leaders (or one Project Leader and one Project Committee member).
+
+> The guaranteed-to-be latest process, approvals & thresholds can be found only in the [Expense Policy](https://owasp.org/www-policy/operational/expense-reimbursement.html).
+
+**Examples for valid expenses**
+
+* ...
+* ...
+* ...
+
+#### AWS Services
+
+...
+
+#### ...
+
+

--- a/leaders.md
+++ b/leaders.md
@@ -1,13 +1,13 @@
 ### Committee Officers
 
 * [Bjoern Kimminich](mailto:bjoern.kimminich@owasp.org) - Chair
-* [Kevin Johnson](mailto:kevin.johnson@owasp.org) - Vice Chair
+* [Jeff Foley](mailto:jeff.foley@owasp.org) - Vice Chair
 * [Donnie Brown](mailto:donnie.brown@owasp.org) - Secretary
 
 **Committee Members**
+* [Jason Gillam](mailto:jason.gillam@owasp.org)
+* [Michael Bargury](mailto:michael.bargury@owasp.org)
 * [Jim Manico](mailto:jim.manico@owasp.org)
-* [Steve Springett](mailto:steve.springett@owasp.org)
-* [Jeff Foley](mailto:jeff.foley@owasp.org)
 
 **Staff Contact**
 * [Harold Blankenship](mailto:harold.blankenship@owasp.com)

--- a/tab_resources.md
+++ b/tab_resources.md
@@ -9,9 +9,11 @@ tags: project-committee
 
 ## Resources
 
-Please use these icons on your OWASP project websites to support a common look & feel.
+{% include support_for_projects.md %}
 
 ### Project Maturity Level Icons
+
+Please use these icons on your OWASP project websites to support a common look & feel.
 
 #### Incubator
 


### PR DESCRIPTION
This section should serve as a light-weight overview of all possible services and assistance towards Projects from the OWASP Foundation. It should always link the the underlying policies with as little inline repetition as possible. Additionally it should
* provide examples
* clearly state that granting any such services depends on adherance to the Good Practices for projects
* clearly state that certain higher-value services might be limited to Lab level or above only
* invite project leaders to contact the Project Committee whenever they have a demand not covered on the page